### PR TITLE
Hot fix retro rt formatting

### DIFF
--- a/wweval/R/get_epidemic_phases_from_rt.R
+++ b/wweval/R/get_epidemic_phases_from_rt.R
@@ -8,6 +8,8 @@
 #'
 #' @param locations A vector of the state abbreviations
 #' @param retro_rt_path  A path to the parquet file of retrospective R(t) estimates
+#' @param location_col_name A string indicating the name of the column
+#' indicating location, default is `state_abb`
 #' @param prob_threshold A numeric between 0 and 1 that defines the threshold
 #' probability R(t) >= 1 or R(t) <= 1. Default is `0.9` from the above paper.
 #'
@@ -17,8 +19,10 @@
 #'
 get_epidemic_phases_from_rt <- function(locations,
                                         retro_rt_path,
+                                        location_col_name = "state_abb",
                                         prob_threshold = 0.9) {
   retro_rt <- arrow::read_parquet(retro_rt_path) |>
+    dplyr::rename(state_abbr = !!sym(location_col_name)) |>
     dplyr::filter(state_abbr %in% locations) |>
     dplyr::mutate(
       week_start_date = cut(reference_date, "week")

--- a/wweval/man/get_epidemic_phases_from_rt.Rd
+++ b/wweval/man/get_epidemic_phases_from_rt.Rd
@@ -4,12 +4,20 @@
 \alias{get_epidemic_phases_from_rt}
 \title{Get epidemic phases from R(t)}
 \usage{
-get_epidemic_phases_from_rt(locations, retro_rt_path, prob_threshold = 0.9)
+get_epidemic_phases_from_rt(
+  locations,
+  retro_rt_path,
+  location_col_name = "state_abb",
+  prob_threshold = 0.9
+)
 }
 \arguments{
 \item{locations}{A vector of the state abbreviations}
 
 \item{retro_rt_path}{A path to the parquet file of retrospective R(t) estimates}
+
+\item{location_col_name}{A string indicating the name of the column
+indicating location, default is \code{state_abb}}
 
 \item{prob_threshold}{A numeric between 0 and 1 that defines the threshold
 probability R(t) >= 1 or R(t) <= 1. Default is \code{0.9} from the above paper.}
@@ -21,6 +29,6 @@ to be daily, for each location, based on the retrospective R(t) estimate.
 \description{
 This function loads in the posterior estimate of the retrospective R(t)
 from NNH. Then it categorizes each week into an epidemic phase based on the
-algorithm used inhttps://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1011200 #nolint
+algorithm used in https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1011200 #nolint
 in the S5 appendix. Code available here: https://github.com/cdcepi/Evaluation-of-case-forecasts-submitted-to-COVID19-Forecast-Hub/blob/b3c379dfd48e8c673f67996014f151ce44cbd8fa/Code/Supplement\%205_Rt_Epi\%20Phases.R #nolint
 }

--- a/wweval/man/get_stan_data_list.Rd
+++ b/wweval/man/get_stan_data_list.Rd
@@ -27,7 +27,8 @@ get_stan_data_list(
 \item{model_type}{string indicating which model we are getting data for
 Options are \code{ww} or \code{hosp}}
 
-\item{forecast_date}{string indicating the forecast date}
+\item{forecast_date}{string indicating the forecast date in ISO 8601 convention
+e.g. YYYY-MM-DD}
 
 \item{forecast_time}{integer indicating the number of days to make a forecast
 for}

--- a/wweval/man/wweval-package.Rd
+++ b/wweval/man/wweval-package.Rd
@@ -26,6 +26,7 @@ Authors:
   \item Andrew Magee \email{rzg0@cdc.gov}
   \item Dylan Morris \email{dylan@dylanhmorris.com} (\href{https://orcid.org/0000-0002-3655-406X}{ORCID})
   \item Scott Olesen \email{ulp7@cdc.gov}
+  \item Damon Bayer \email{xum8@cdc.gov}
 }
 
 Other contributors:


### PR DESCRIPTION
Minor change to allow for allow for more flexibility in the way that retrospective R(t)s are formatted (initially the column name was `state_abbr`, now its `state_abb`)