### PR TITLE
Quick fix of the hospital admissions post processing

### DIFF
--- a/_targets_eval_postprocessing.R
+++ b/_targets_eval_postprocessing.R
@@ -179,14 +179,14 @@ combined_targets <- list(
     name = convergence_df_ww,
     command = get_convergence_df(
       all_flags_ww,
-      default_scenario = "status_quo"
+      scenario = "status_quo"
     ) |>
       dplyr::rename(any_flags_ww = any_flags)
   ),
   tar_target(
     name = convergence_df_hosp,
     command = get_convergence_df(all_flags_hosp,
-      default_scenario = "no_wastewater"
+      scenario = "no_wastewater"
     ) |>
       dplyr::rename(any_flags_hosp = any_flags)
   ),

--- a/wweval/R/eval_post_process.R
+++ b/wweval/R/eval_post_process.R
@@ -356,7 +356,7 @@ eval_post_process_hosp <- function(config_index,
   # Save forecasted quantiles locally as well as via
   # targets caching just for backup
   save_table(
-    data_to_save = hosp_model_quantiles,
+    data_to_save = full_hosp_model_quantiles,
     type_of_output = "quantiles",
     output_dir = output_dir,
     scenario = "no_wastewater",


### PR DESCRIPTION
Very happy we unlinked post processing and fitting, bc this will need to be rerun on azure but just the postprocessing. The change here is I just want to have the full set of quantiles for the hospital admissions model (not just the nowcast and forecast period).

I also scope creep fixed a bug in the calling of a function argument in the targets pipeline.

Perhaps can rerun this as part of the azure demo tomorrow... 