### PR TITLE
add a warning message and a new file to write out missing files

### DIFF
--- a/wweval/R/combine_outputs.R
+++ b/wweval/R/combine_outputs.R
@@ -68,6 +68,10 @@ combine_outputs <- function(output_type =
         error = function(e) {}
       )
     } else {
+      warning(glue::glue(
+        "File missing for {this_scenario}",
+        "in {this_location} on {this_forecast_date}"
+      ))
       # Create a tibble of the combos that are missing, to save
       this_failed_output <- tibble(
         scenario = this_scenario,
@@ -83,10 +87,6 @@ combine_outputs <- function(output_type =
   }
 
   if (nrow(flag_failed_output) != 0) {
-    warning(glue::glue(
-      "File missing for {this_scenario}",
-      "in {this_location} on {this_forecast_date}"
-    ))
     # Save the missing files in a new subfolder in the eval_output_subdir
     cfaforecastrenewalww::create_dir(file.path(
       eval_output_subdir,


### PR DESCRIPTION
This PR adds the functionality to generate warning messages when our "roll-your-own" version of `tar_combine()` (called `combine_outputs()` tries to load in a file and fails. This is helpful because some of these seem to have been killed jobs on Azure that we would only know by spot checking manually (which is not ideal) and we would just need to rerun them.

I added functionality to write it into a file, we could make this optional. My thinking here is most of this analysis is really for our own evaluation analysis rather than very general tooling, so its maybe okay to do something like this, but happy to change if we want to push towards maximizing user generality. 