### PR TITLE
Add targets to save a pdf of the wastewater data by state

### DIFF
--- a/_targets_eval_postprocessing.R
+++ b/_targets_eval_postprocessing.R
@@ -106,6 +106,33 @@ upstream_targets <- list(
       ww_data_mapping = eval_config$ww_data_mapping
     )
   ),
+  tar_target(
+    name = grouped_eval_ww_data,
+    command = eval_ww_data |>
+      dplyr::group_by(location) |>
+      targets::tar_group(),
+    iteration = "group"
+  ),
+  tar_target(
+    name = plot_ww_eval_data,
+    command = get_plot_ww_data(
+      grouped_eval_ww_data
+    ),
+    pattern = map(grouped_eval_ww_data),
+    iteration = "list"
+  ),
+  tar_target(
+    name = save_pdf_of_ww_data,
+    command = ggsave(
+      filename = file.path(
+        eval_config$figure_dir,
+        glue::glue("eval_ww_data.pdf")
+      ),
+      plot = gridExtra::marrangeGrob(plot_ww_eval_data, nrow = 1, ncol = 1),
+      width = 8.5, height = 11
+    )
+  ),
+
   # Returns a dataframe with each location and date and a corresponding
   # epidemic phase
   tar_target(
@@ -964,8 +991,8 @@ list(
   upstream_targets,
   combined_targets,
   head_to_head_targets,
-  manuscript_figures
+  manuscript_figures,
   # scenario_targets,
-  # hub_targets,
-  # hub_comparison_plots
+  hub_targets,
+  hub_comparison_plots
 )

--- a/wweval/R/plots.R
+++ b/wweval/R/plots.R
@@ -1251,6 +1251,7 @@ get_plot_ww_data <- function(eval_data) {
 
   p <- ggplot(eval_data) +
     geom_point(aes(x = date, y = log(ww)), size = 0.5) +
+    geom_line(aes(x = date, y = log(ww)), size = 0.5) +
     geom_point(
       data = eval_data |> dplyr::filter(flag_as_ww_outlier == 1),
       aes(x = date, y = log(ww)),

--- a/wweval/R/plots.R
+++ b/wweval/R/plots.R
@@ -1239,3 +1239,45 @@ get_qq_plot <- function(scores,
 
   return(p)
 }
+
+get_plot_ww_data <- function(eval_data) {
+  eval_data <- eval_data |>
+    dplyr::mutate(
+      lab_site_name = glue::glue("Site: {site}, lab: {lab}")
+    )
+  loc <- eval_data |>
+    dplyr::distinct(location) |>
+    dplyr::pull()
+
+  p <- ggplot(eval_data) +
+    geom_point(aes(x = date, y = log(ww)), size = 0.5) +
+    geom_point(
+      data = eval_data |> dplyr::filter(flag_as_ww_outlier == 1),
+      aes(x = date, y = log(ww)),
+      fill = "red", color = "red", size = 0.5
+    ) +
+    geom_point(
+      data = eval_data |> dplyr::filter(below_LOD == 1),
+      aes(x = date, y = log(ww)),
+      fill = "darkblue", color = "darkblue", size = 0.5
+    ) +
+    facet_wrap(~lab_site_name) +
+    theme_bw() +
+    theme(
+      axis.text.x = element_text(
+        size = 8, vjust = 1,
+        hjust = 1, angle = 45
+      ),
+      axis.title.x = element_text(size = 12),
+      axis.title.y = element_text(size = 10),
+      plot.title = element_text(
+        size = 10,
+        vjust = 0.5, hjust = 0.5
+      )
+    ) +
+    xlab("") +
+    ylab("Log(genome copies per mL)") +
+    ggtitle(glue::glue("Wastewater concentration data in {loc}"))
+
+  return(p)
+}


### PR DESCRIPTION
This PR closes #116. It adds to the pipeline to save the wastewater data visualized with one page per state as a pdf. See PDF [here](https://github.com/cdcent/cfa-forecast-renewal-ww/issues/762). We will use this to visually inspect whether there are states/dates where wastewater data should be excluded. In particular, I have identified a few states to look at from last week based on very poor model performance over all. 

