### PR TITLE
Use `scoringutils::transform_forecasts()` instead of manual transform

### DIFF
--- a/wweval/man/get_full_scores.Rd
+++ b/wweval/man/get_full_scores.Rd
@@ -23,5 +23,6 @@ a dataframe containing a score for each day in the nowcast
 and forecast period
 }
 \description{
-Logs the truth data and forecasts and scores using scoringutils
+Uses scoringutils to transform data and predictions using a log transform
+with a log shift of 1, and return the default scoring metrics
 }

--- a/wweval/man/get_scores_from_quantiles.Rd
+++ b/wweval/man/get_scores_from_quantiles.Rd
@@ -25,5 +25,6 @@ a dataframe containing a score for each day in the nowcast
 and forecast period
 }
 \description{
-Logs the truth data and forecasts and scores using scoringutils
+Uses scoringutils to transform data and predictions using a log transform
+with a log shift of 1, and return the default scoring metrics
 }


### PR DESCRIPTION
This PR closes #113. I had been manually transforming data and predictions and then using score. This uses built in functionality in scoringutils. Setting the logshift to 1 not 1e-8. 