### PR TITLE
Add to targets pipeline generation of a pdf with input hospital data for each location and forecast date

### DIFF
--- a/_targets_eval_postprocessing.R
+++ b/_targets_eval_postprocessing.R
@@ -374,6 +374,32 @@ head_to_head_targets <- list(
       ) |>
       add_horizons()
   ),
+  tar_target(
+    name = grouped_hosp_data,
+    command = hosp_quantiles_filtered |>
+      dplyr::distinct(location, forecast_date, date, calib_data) |>
+      group_by(location, forecast_date) |>
+      targets::tar_group()
+  ),
+  tar_target(
+    name = plot_input_hosp_data,
+    command = get_plot_input_hosp_data(grouped_hosp_data),
+    pattern = map(grouped_hosp_data),
+    iteration = "list"
+  ),
+  tar_target(
+    name = save_pdf_of_hosp_data,
+    command = ggsave(
+      filename = file.path(
+        eval_config$figure_dir,
+        glue::glue("input_hosp_data.pdf")
+      ),
+      plot = gridExtra::marrangeGrob(plot_input_hosp_data, nrow = 5, ncol = 2),
+      width = 8.5, height = 11
+    )
+  ),
+
+
   # Do the same thing for the sampled scores, combining ww and hosp under
   # the status quo scenario, filtering to the locations and forecast dates
   # with sufficient wastewater, and then joining the convergence flags

--- a/_targets_eval_postprocessing.R
+++ b/_targets_eval_postprocessing.R
@@ -1351,9 +1351,9 @@ hub_comparison_plots <- list(
 list(
   upstream_targets,
   combined_targets,
-  head_to_head_targets,
-  manuscript_figures,
-  # scenario_targets,
-  hub_targets,
-  hub_comparison_plots
+  head_to_head_targets
+  # manuscript_figures,
+  # # scenario_targets,
+  # hub_targets,
+  # hub_comparison_plots
 )

--- a/wweval/R/plots.R
+++ b/wweval/R/plots.R
@@ -1,3 +1,50 @@
+#' Plot the input hospital admissions data from a single location and
+#' forecast date
+#'
+#' @param hosp_data input hospital admissions data for a single location
+#' and forecast date
+#'
+#' @return a ggplot object with a single location and forecast dates
+#' input hospital admissions data
+#' @export
+get_plot_input_hosp_data <- function(hosp_data) {
+  forecast_date <- hosp_data |>
+    dplyr::distinct(forecast_date) |>
+    dplyr::pull()
+  location <- hosp_data |>
+    dplyr::distinct(location) |>
+    dplyr::pull()
+
+  p <- ggplot(hosp_data) +
+    geom_line(aes(x = date, y = calib_data)) +
+    geom_point(aes(x = date, y = calib_data)) +
+    scale_x_date(
+      date_breaks = "1 week",
+      labels = scales::date_format("%Y-%m-%d")
+    ) +
+    ylab("Daily hospital admissions") +
+    xlab("") +
+    ggtitle(glue::glue("{location}, as of {forecast_date}")) +
+    theme_bw() +
+    theme(
+      axis.text.x = element_text(
+        size = 8, vjust = 1,
+        hjust = 1, angle = 45
+      ),
+      axis.title.x = element_text(size = 12),
+      axis.title.y = element_text(size = 12),
+      plot.title = element_text(
+        size = 10,
+        vjust = 0.5, hjust = 0.5
+      )
+    )
+
+  return(p)
+}
+
+
+
+
 #' Get plot of wastewater data compared to model draws
 #'
 #' @param draws_w_data A long tidy dataframe containing draws from the model of


### PR DESCRIPTION
For manual review of the admissions data to flag forecast date/locations with major outliers, which we will add to our table of exclusions once we confirm the date they correspond to. 