### PR TITLE
Filter to only log scores

### DIFF
--- a/_targets_eval_postprocessing.R
+++ b/_targets_eval_postprocessing.R
@@ -375,6 +375,7 @@ head_to_head_targets <- list(
       all_ww_scores |>
         dplyr::filter(scenario == "status_quo")
     ) |>
+      dplyr::filter(scale == "log") |>
       dplyr::left_join(table_of_loc_dates_w_ww,
         by = c("location", "forecast_date")
       ) |>
@@ -407,6 +408,7 @@ head_to_head_targets <- list(
       all_ww_scores_quantiles |>
         dplyr::filter(scenario == "status_quo")
     ) |>
+      dplyr::filter(scale == "log") |>
       dplyr::left_join(table_of_loc_dates_w_ww,
         by = c("location", "forecast_date")
       ) |>


### PR DESCRIPTION
We previously added functionality to pass around natural scale and log scale scores-- had forgot to filter for just log scale scores.

We could also set this up as a config variable, but I think this is okay for now