### PR TITLE
add supp fig, add asterisk to fig4

### DIFF
--- a/_targets_eval_postprocessing.R
+++ b/_targets_eval_postprocessing.R
@@ -1689,6 +1689,15 @@ hub_comparison_plots <- list(
     )
   ),
   tar_target(
+    name = sfig5_plot_wis_t_all_time,
+    command = make_fig5_average_wis(
+      all_scores = summarized_scores_oct_mar,
+      models_to_show = unique(combine_scores_oct_mar$model),
+      time_period = "Oct 2023-Mar 2024",
+      fig_file_dir = eval_config$ms_fig_dir
+    )
+  ),
+  tar_target(
     name = fig5_overall_performance,
     command = make_fig5_hub_performance(
       all_scores = summarized_scores_oct_mar,

--- a/wweval/R/ms_fig4.R
+++ b/wweval/R/ms_fig4.R
@@ -900,7 +900,7 @@ make_fig4_avg_wis_over_time <- function(wis_scores,
     dplyr::mutate(
       model = case_when(
         model == "ww" ~ "cfa-wwrenewal(real-time)",
-        model == "hosp" ~ "cfa-hosponlyrenewal(real-time)"
+        model == "hosp" ~ "cfa-hosponlyrenewal(real-time)*"
       )
     )
 

--- a/wweval/R/ms_fig5.R
+++ b/wweval/R/ms_fig5.R
@@ -105,6 +105,7 @@ make_fig5_bar_chart <- function(scores,
 #' @param horizon_time_in_weeks horizon time in weeks to summarize over, default
 #' is `NULL` which means that the scores are summarized over the nowcast period
 #' and the 4 week forecast period
+#' @param fig_file_dir string indicating where to save fig, default is NULL
 #'
 #' @return a ggplot object of WIS scores over time colored by model, for the
 #' real-time cfa model from Feb - Mar and the retrospective CFA model over
@@ -115,7 +116,8 @@ make_fig5_average_wis <- function(all_scores,
                                   cfa_real_time_scores = c(),
                                   models_to_show,
                                   time_period,
-                                  horizon_time_in_weeks = NULL) {
+                                  horizon_time_in_weeks = NULL,
+                                  fig_file_dir = NULL) {
   subset_model_scores <- all_scores |>
     dplyr::filter(model %in% !!models_to_show)
 
@@ -176,6 +178,17 @@ make_fig5_average_wis <- function(all_scores,
       legend.title = element_blank(),
       legend.text = element_text(size = 7)
     )
+
+  if (!is.null(fig_file_dir)) {
+    p <- p + guides(color = guide_legend(nrow = 3))
+    ggsave(p,
+      height = 6, width = 11,
+      filename = file.path(
+        fig_file_dir,
+        glue::glue("sfig_wis_over_time_all_models.png")
+      )
+    )
+  }
 
   return(p)
 }

--- a/wweval/man/make_fig5_average_wis.Rd
+++ b/wweval/man/make_fig5_average_wis.Rd
@@ -9,7 +9,8 @@ make_fig5_average_wis(
   cfa_real_time_scores = c(),
   models_to_show,
   time_period,
-  horizon_time_in_weeks = NULL
+  horizon_time_in_weeks = NULL,
+  fig_file_dir = NULL
 )
 }
 \arguments{
@@ -30,6 +31,8 @@ from the COVID-19 forecast hub to include in the plot.}
 \item{horizon_time_in_weeks}{horizon time in weeks to summarize over, default
 is \code{NULL} which means that the scores are summarized over the nowcast period
 and the 4 week forecast period}
+
+\item{fig_file_dir}{string indicating where to save fig, default is NULL}
 }
 \value{
 a ggplot object of WIS scores over time colored by model, for the


### PR DESCRIPTION
Minor fixes to address recent changes:
- add asterisk to the name of hosp only model in real time 
- save a version of the wis over time figure for all the hub models