### PR TITLE
Allow 'both' jobs in setup_job

### DIFF
--- a/batch/README.md
+++ b/batch/README.md
@@ -142,16 +142,16 @@ A job is a set of tasks. Each task (by default) gets handed to 1 "node" (virtual
 > [!NOTE]
 > Containers have a default working directory. Azure Batch tasks _don't_ default to starting in the container's own default working directory. In this tutorial, we _would_ like to start our tasks in the container's working directory. For that reason, `setup_job.py` contains [this line](https://github.com/cdcent/cfa-forecast-renewal-ww/blob/91080eaf42ad63f3b1de9e89c6221f58fa55a941/batch/setup_job.py#L70), which explicitly instructs Azure to use the container's default working directory.
 
-In our example, `setup_job.py` creates a bunch of tasks. All of them consist of running the following command for different values of `{config_index}` (an integer), `{job_type}` (one of `fit` and `postprocess`), and `{model}` (one of `ww` and `hosp`):
+In our example, `setup_job.py` creates a bunch of tasks. All of them consist of running the following command for different values of `{config_index}` (an integer), `{model}` (one of `ww` and `hosp`),  `{task_type}` (one of `fit` and `postprocess`).
 ```
-Rscript run_eval.R {config_index} input/config/eval/example_eval_config.yaml input/params.toml {model} {job_type}
+Rscript run_eval.R {config_index} input/config/eval/example_eval_config.yaml input/params.toml {model} {task_type}
 ```
 
-Invoking the command above performs either model fitting or model postprocessing for one of the forecasting problems specified in `example_eval_config.yaml`. A "forecasting problem" here means a forecast for a given location and date. Each forecasting problem has a corresponding `config_index` in the evaluation configuration `.yaml` file. For example, this command starts a fitting job for the wastewater model with the 3rd entry in `example_eval_config.yaml`:
+Invoking the command above performs either model fitting or model postprocessing for one of the forecasting problems specified in `example_eval_config.yaml`. A "forecasting problem" here means a forecast for a given location and date. Each forecasting problem has a corresponding `config_index` in the evaluation configuration `.yaml` file. For example, this command runs model fitting with the wastewater model for the 3rd entry in `example_eval_config.yaml`:
 ```
 Rscript run_eval.R 3 input/config/eval/example_eval_config.yaml input/params.toml ww fit
 ```
-This command starts a post-processing job for the 6th entry in the config for the hospital admissions-only model:
+This command runs model post-processing with the hospital admissions-only model for the 6th entry in the config:
 ```
 Rscript pipeline/run_eval.R 6 input/config/eval/example_eval_config.yaml input/params.toml hosp postprocess
 ```
@@ -160,30 +160,22 @@ The file [`input/params.toml`][../input/params.toml] specifies hyperparameters f
 
 To save you writing this all out by hand, `setup_job.py` loops over all the values of `{config_index}` in `input/config/eval/example_eval_config.yaml`, creating tasks for each one.
 
-#### Model fitting
-Let's run `setup_job.py` to create a model fitting job and its constituent tasks. We'll name it `my-demo-fit-job` and have it run on the `wastewater-demo-pool` we just created. We'll use our local copy of the example configuration file (`example_eval_config.yaml`) and the corresponding copy of it Blob storage container `wastewater-input`.
+By default, it creates a set of model fitting tasks and their associated postprocessing tasks for all entries in the specified config file.
+
+
+#### Model fitting and postprocessing
+Let's run `setup_job.py` to create a model fitting and postprocessing job. We'll name our job `my-demo-job` and have it run on the `wastewater-demo-pool` we just created. We'll use our local copy of the example configuration file (`example_eval_config.yaml`) and the corresponding copy of it Blob storage container `wastewater-input`.
 
 > [!CAUTION]
 > Make sure your local and remote config files are identical. Otherwise, the pipeline may error or behave unexpectedly. We hope to deduplicate the configs in a future refactor.
 
 ```bash
-python3 batch/setup_job.py input/config/eval/example_eval_config.yaml fit my-demo-fit-job wastewater-demo-pool
+python3 batch/setup_job.py input/config/eval/example_eval_config.yaml both my-demo-fit-job wastewater-demo-pool
 ```
 
-This should create a job named `my-demo-fit-job` consisting of tasks that are named by forecast dates, locations, scenarios and the the job type. (here `fit`). Confirm that this has happened by looking for the job and its tasks in the Azure Batch Explorer or in the Batch section of the Azure web portal. Once your fitting job is finished, examine the `wastewater-example-output` Blob storage container and confirm that output files have been generated.
+This should create a job named `my-demo-job` consisting of tasks that are named by forecast dates, locations, scenarios and task type. (either `fit` or `postprocess`). Confirm that this has happened by looking for the job and its tasks in the Azure Batch Explorer or in the Batch section of the Azure web portal. Once your fitting job is finished, examine the `wastewater-example-output` Blob storage container and confirm that output files have been generated.
 
-#### Model postprocessing
-Next, set up a second job to postprocess the results of the fitting job by running:
-
-```bash
-python3 batch/setup_job.py input/config/eval/example_eval_config.yaml post_process my-demo-postprocess-job wastewater-demo-pool
-```
-
-Note that you should wait for all tasks in `fit` to finish before kicking off the `postprocess` job. Eventually, we may unify these into a single job, in which the postprocess tasks wait for the corresponding fitting tasks to finish, but we have not yet implemented this.
-
-> [!CAUTION]
-> If you or someone else previously have previously created a job and tasks with these names the script will error, telling you that the tasks already exist. To fix this, delete the tasks, delete and re-create the job, or create a new job with a distinct name, e.g. `my-demo-fit-job-2`.
-3
+If you watch the tasks in action, you'll see that the `postprocess` tasks do not kick off until after their associated `fit` tasks have finished. This is because `setup_job.py` is configured to make [the postprocess tasks "depend" on their associated fit tasks](https://learn.microsoft.com/en-us/azure/batch/batch-task-dependencies).
 
 ## Customizing and configuring the evaluation pipeline
 

--- a/batch/README.md
+++ b/batch/README.md
@@ -14,7 +14,7 @@ This guide assumes you are working on a Debian/Ubuntu family Linux machine or in
 
 ### Installing needed command line utilities.
 
-#### Update apt
+#### Update `apt`
 Before installing things with `apt`, it's good to update package lists:
 
 ```bash
@@ -170,12 +170,17 @@ Let's run `setup_job.py` to create a model fitting and postprocessing job. We'll
 > Make sure your local and remote config files are identical. Otherwise, the pipeline may error or behave unexpectedly. We hope to deduplicate the configs in a future refactor.
 
 ```bash
-python3 batch/setup_job.py input/config/eval/example_eval_config.yaml both my-demo-fit-job wastewater-demo-pool
+python3 batch/setup_job.py input/config/eval/example_eval_config.yaml both my-demo-job wastewater-demo-pool
 ```
 
-This should create a job named `my-demo-job` consisting of tasks that are named by forecast dates, locations, scenarios and task type. (either `fit` or `postprocess`). Confirm that this has happened by looking for the job and its tasks in the Azure Batch Explorer or in the Batch section of the Azure web portal. Once your fitting job is finished, examine the `wastewater-example-output` Blob storage container and confirm that output files have been generated.
+This should create a job named `my-demo-job` consisting of tasks that are named by forecast dates, locations, scenarios and task type. (either `fit` or `postprocess`). Confirm that this has happened by looking for the job and its tasks in the Azure Batch Explorer or in the Batch section of the Azure web portal.
 
-If you watch the tasks in action, you'll see that the `postprocess` tasks do not kick off until after their associated `fit` tasks have finished. This is because `setup_job.py` is configured to make [the postprocess tasks "depend" on their associated fit tasks](https://learn.microsoft.com/en-us/azure/batch/batch-task-dependencies).
+> [!CAUTION]
+> If you or someone else previously have previously created a job and tasks with these names the script will error, telling you that the tasks already exist. To fix this, delete the tasks, delete and re-create the job, or create a new job with a distinct name, e.g. `my-demo-fit-job-2`.
+
+Once your job is finished, examine the `wastewater-example-output` Blob storage container and confirm that output files have been generated.
+
+If you watch the tasks in action (e.g. via the Batch Explorer), you'll see that the `postprocess` tasks do not kick off until after their associated `fit` tasks have finished. This is because `setup_job.py` is configured to make [the postprocess tasks "depend" on their associated fit tasks](https://learn.microsoft.com/en-us/azure/batch/batch-task-dependencies).
 
 ## Customizing and configuring the evaluation pipeline
 
@@ -185,30 +190,27 @@ This section explains how to customize and configure the pipeline.
 `setup_job.py` takes a number of command line arguments, as follows:
 
 ```
-usage: setup_job.py [-h]
-                    [--container-image-name CONTAINER_IMAGE_NAME]
+usage: setup_job.py [-h] [--job-type JOB_TYPE] [--container-image-name CONTAINER_IMAGE_NAME]
                     [--container-image-version CONTAINER_IMAGE_VERSION]
                     [--exclude-ww-model | --no-exclude-ww-model]
-                    eval_config_file job_type job_id pool_id
+                    eval_config_file job_id pool_id
 
 Set up an Azure batch job from an evaluation configuration file.
 
 positional arguments:
   eval_config_file      Path to a YAML-formatted configuration file
-  job_type              Type of job to run (either `fit` or
-                        `postprocess`)
   job_id                Name for the Azure batch job
-  pool_id               Name of the Azure batch pool on which to run
-                        the job
+  pool_id               Name of the Azure batch pool on which to run the job
 
 options:
   -h, --help            show this help message and exit
+  --job-type JOB_TYPE   Type(s) of job to run (`fit`, `postprocess`, or `both`) (default: both)
   --container-image-name CONTAINER_IMAGE_NAME
-                        Name of the container to use for the job.
+                        Name of the container to use for the job. (default: renewalww)
   --container-image-version CONTAINER_IMAGE_VERSION
-                        Version of the container to use for the job.
+                        Version of the container to use for the job. (default: latest)
   --exclude-ww-model, --no-exclude-ww-model
-                        Exclude the wastewater model from fitting?
+                        Exclude the wastewater model from fitting? (default: None)
 ```
 
 As the above suggests, you can always view this help message by running
@@ -216,7 +218,24 @@ As the above suggests, you can always view this help message by running
 ```bash
 python setup_job.py -h
 ```
+
+#### Custom container images and versions.
 The default values of `--container-image-name` and `--container-image-version` are `renewalww` and `latest`, respectively. This corresponds to the container image built and pushed via Github actions that reflecting the current state of `prod`.
+
+#### Custom job types
+The default `--job-type`, `both`, means running fitting followed by postprocessing tasks. We could override it to set up a fitting-only job:
+
+```bash
+python3 batch/setup_job.py input/config/eval/example_eval_config.yaml both my-demo-fit-job wastewater-demo-pool --job-type fit
+```
+
+or a manual postprocessing-only job:
+
+```bash
+python3 batch/setup_job.py input/config/eval/example_eval_config.yaml both my-demo-postprocess-job wastewater-demo-pool --job-type postprocess
+```
+
+Note that if you run a manual `fit`-only job followed by a manual `postprocess`-only job, you will need to confirm manually that fitting tasks have finished before kicking off their associated postprocessing tasks. In general, only kick off a manual postprocessing job once the entire associated manual fitting job has completed.
 
 ### Creating a configuration file
 The [`src/setup_eval.R`][../src/setup_eval.R] script can help you write properly formatted evaluation configuration YAML files. Remember to mirror config versions between your local `input/config/eval` directory and the one in your input Azure Blob storage container.

--- a/batch/requirements.txt
+++ b/batch/requirements.txt
@@ -14,7 +14,7 @@ azure-mgmt-batch==18.0.0
 azure-mgmt-compute==33.1.0
 azure-mgmt-core==1.5.0
 azure-storage-blob==12.24.1
-azuretools @ git+https://github.com/cdcgov/cfa-azuretools@ff598475b5dbff25666fcabf0a38ebd8225f9ca0
+azuretools @ git+https://github.com/cdcgov/cfa-azuretools@c1791847c4abc2c8e02a9aceb6dab26450c21e08
 babel==2.17.0
 build==1.2.2.post1
 certifi==2025.1.31

--- a/batch/setup_job.py
+++ b/batch/setup_job.py
@@ -192,7 +192,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=(
             "Set up an Azure batch job from an evaluation configuration file."
-        )
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "eval_config_file",

--- a/batch/setup_job.py
+++ b/batch/setup_job.py
@@ -71,10 +71,11 @@ def main(
     creds = EnvCredentialHandler()
 
     batch_service_client = get_batch_service_client(creds)
-
+    uses_deps = job_type == "both"
     job = batchmodels.JobAddParameter(
         id=job_id,
         pool_info=batchmodels.PoolInformation(pool_id=pool_id),
+        uses_task_dependencies=uses_deps,
     )
 
     try:
@@ -124,7 +125,7 @@ def main(
         scenario: str,
         model: str,
         task_type: str,
-        deps: bool,
+        uses_task_dependencies: bool,
     ) -> None:
         """
         Helper function to add tasks as we loop through.
@@ -132,7 +133,7 @@ def main(
         task_name = f"{scenario}-{forecast_date}-{location}"
         task_id = f"{job_id}-{task_type}-{task_name}"
         task_deps = None
-        if task_type == "postprocess" and deps:
+        if task_type == "postprocess" and uses_task_dependencies:
             task_deps = batchmodels.TaskDependencies(
                 task_ids=[f"{job_id}-fit-{task_name}"]
             )
@@ -180,7 +181,7 @@ def main(
                 scenario=scen if model == "ww" else "no_wastewater",
                 model=model,
                 task_type=task_type,
-                deps=(job_type == "both"),
+                uses_task_dependencies=uses_deps,
             )
             pass
         pass

--- a/batch/setup_job.py
+++ b/batch/setup_job.py
@@ -199,7 +199,7 @@ if __name__ == "__main__":
         help="Path to a YAML-formatted configuration file",
     )
     parser.add_argument(
-        "job_types",
+        "job_type",
         type=str,
         help="Type(s) of job to run (`fit`, `postprocess`, or `both`)",
     )

--- a/batch/setup_job.py
+++ b/batch/setup_job.py
@@ -130,7 +130,7 @@ def main(
         Helper function to add tasks as we loop through.
         """
         task_name = f"{scenario}-{forecast_date}-{location}"
-        task_id = f"{job_id}-{job_type}-{task_name}"
+        task_id = f"{job_id}-{task_type}-{task_name}"
         task_deps = None
         if task_type == "postprocess" and deps:
             task_deps = batchmodels.TaskDependencies(

--- a/batch/setup_job.py
+++ b/batch/setup_job.py
@@ -123,7 +123,7 @@ def main(
         forecast_date: str,
         scenario: str,
         model: str,
-        job_type: str,
+        task_type: str,
         deps: bool,
     ) -> None:
         """
@@ -132,7 +132,7 @@ def main(
         task_name = f"{scenario}-{forecast_date}-{location}"
         task_id = f"{job_id}-{job_type}-{task_name}"
         task_deps = None
-        if job_type == "postprocess" and deps:
+        if task_type == "postprocess" and deps:
             task_deps = batchmodels.TaskDependencies(
                 [f"{job_id}-fit-{task_name}"]
             )
@@ -145,7 +145,7 @@ def main(
             f"input/config/eval/{config_name}.yaml "
             "input/params.toml "
             f"{model} "
-            f"{job_type}"
+            f"{task_type}"
             f" > {log_dir}/{task_name}-stdout.txt "
             f" 2> {log_dir}/{task_name}-stderr.txt"
             "'"
@@ -165,7 +165,7 @@ def main(
         if job_type == "both"
         else ensure_listlike(job_type)
     )
-    for model, job_type in itertools.product(to_run, task_types):
+    for model, task_type in itertools.product(to_run, task_types):
         for i_row, (loc, f_date, scen) in enumerate(
             zip(
                 eval_spec[f"location_{model}"],
@@ -179,7 +179,7 @@ def main(
                 forecast_date=f_date,
                 scenario=scen if model == "ww" else "no_wastewater",
                 model=model,
-                job_type=job_type,
+                task_type=task_type,
                 deps=(job_type == "both"),
             )
             pass

--- a/batch/setup_job.py
+++ b/batch/setup_job.py
@@ -1,4 +1,5 @@
 import argparse
+import itertools
 from pathlib import Path
 
 import azure.batch.models as batchmodels
@@ -28,8 +29,10 @@ def main(
         Path to the YAML-formatted evaluation configuration file
 
     job_type
-        Either ``fit`` to run model fitting or ``postprocess`` to
-        run post-processing.
+        ``fit`` to run model fitting, ``postprocess`` to
+        run post-processing, or ``both`` to run both,
+        with postprocess tasks as dependencies of their
+        associated fit jobs.
 
     job_id
         ID for the batch job to create.
@@ -59,11 +62,10 @@ def main(
     None
         Creating the job and its tasks as a side effect.
     """
-    valid_job_types = ["fit", "postprocess"]
+    valid_job_types = ["fit", "postprocess", "both"]
     if job_type not in valid_job_types:
         raise ValueError(
-            f"Invalid job_type. Must be one of {valid_job_types}, "
-            f"but got {job_type}."
+            f"Invalid job_type. Must be one of {valid_job_types}, but got {job_type}."
         )
 
     creds = EnvCredentialHandler()
@@ -121,11 +123,20 @@ def main(
         forecast_date: str,
         scenario: str,
         model: str,
+        job_type: str,
+        deps: bool,
     ) -> None:
         """
         Helper function to add tasks as we loop through.
         """
-        task_name = f"{job_type}-{scenario}-" f"{forecast_date}-{location}"
+        task_name = f"{scenario}-{forecast_date}-{location}"
+        task_id = f"{job_id}-{job_type}-{task_name}"
+        task_deps = None
+        if job_type == "postprocess" and deps:
+            task_deps = batchmodels.TaskDependencies(
+                [f"{job_id}-fit-{task_name}"]
+            )
+
         base_call = (
             "/bin/sh -c '"
             f"mkdir -p {log_dir}; "
@@ -140,15 +151,21 @@ def main(
             "'"
         )
         task = get_task_config(
-            f"{job_id}-{task_name}",
+            task_id,
             base_call=base_call,
             container_settings=container_settings,
+            depends_on=task_deps,
         )
         batch_service_client.task.add(job_id, task)
         return None
 
     to_run = ["hosp"] if exclude_ww_model else ["ww", "hosp"]
-    for model in to_run:
+    task_types = (
+        ["fit", "postprocess"]
+        if job_type == "both"
+        else ensure_listlike(job_type)
+    )
+    for model, job_type in itertools.product(to_run, task_types):
         for i_row, (loc, f_date, scen) in enumerate(
             zip(
                 eval_spec[f"location_{model}"],
@@ -162,6 +179,8 @@ def main(
                 forecast_date=f_date,
                 scenario=scen if model == "ww" else "no_wastewater",
                 model=model,
+                job_type=job_type,
+                deps=(job_type == "both"),
             )
             pass
         pass
@@ -171,8 +190,7 @@ def main(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=(
-            "Set up an Azure batch job from an "
-            "evaluation configuration file."
+            "Set up an Azure batch job from an evaluation configuration file."
         )
     )
     parser.add_argument(
@@ -181,9 +199,9 @@ if __name__ == "__main__":
         help="Path to a YAML-formatted configuration file",
     )
     parser.add_argument(
-        "job_type",
+        "job_types",
         type=str,
-        help="Type of job to run (either `fit` or `postprocess`)",
+        help="Type(s) of job to run (`fit`, `postprocess`, or `both`)",
     )
     parser.add_argument(
         "job_id", type=str, help="Name for the Azure batch job"

--- a/batch/setup_job.py
+++ b/batch/setup_job.py
@@ -134,7 +134,7 @@ def main(
         task_deps = None
         if task_type == "postprocess" and deps:
             task_deps = batchmodels.TaskDependencies(
-                [f"{job_id}-fit-{task_name}"]
+                task_ids=[f"{job_id}-fit-{task_name}"]
             )
 
         base_call = (

--- a/batch/setup_job.py
+++ b/batch/setup_job.py
@@ -12,9 +12,9 @@ from azuretools.util import ensure_listlike
 
 def main(
     eval_config_file: str,
-    job_type: str,
     job_id: str,
     pool_id: str,
+    job_type: str,
     exclude_ww_model: bool,
     container_image_name: str = "renewalww",
     container_image_version: str = "latest",
@@ -28,18 +28,18 @@ def main(
     eval_config_file
         Path to the YAML-formatted evaluation configuration file
 
-    job_type
-        ``fit`` to run model fitting, ``postprocess`` to
-        run post-processing, or ``both`` to run both,
-        with postprocess tasks as dependencies of their
-        associated fit jobs.
-
     job_id
         ID for the batch job to create.
 
     pool_id
         ID of the batch pool on which to run the job.
         Must already exist.
+
+    job_type
+        ``fit`` to run model fitting, ``postprocess`` to
+        run post-processing, or ``both`` to run both,
+        with postprocess tasks as dependencies of their
+        associated fit jobs.
 
     exclude_ww_model
         If ``True``, fit only the hospital admissions-only model,
@@ -199,11 +199,7 @@ if __name__ == "__main__":
         type=str,
         help="Path to a YAML-formatted configuration file",
     )
-    parser.add_argument(
-        "job_type",
-        type=str,
-        help="Type(s) of job to run (`fit`, `postprocess`, or `both`)",
-    )
+
     parser.add_argument(
         "job_id", type=str, help="Name for the Azure batch job"
     )
@@ -212,6 +208,13 @@ if __name__ == "__main__":
         "pool_id",
         type=str,
         help="Name of the Azure batch pool on which to run the job",
+    )
+
+    parser.add_argument(
+        "--job-type",
+        type=str,
+        default="both",
+        help="Type(s) of job to run (`fit`, `postprocess`, or `both`)",
     )
 
     parser.add_argument(


### PR DESCRIPTION
This allows a single job to handle both fitting and postprocessing. In that scheme, postprocessing tasks have their associated fitting tasks as dependencies, so they don't start until/unless the fitting jobs are complete. The manual first fit, then postprocess scheme remains supported.