### PR TITLE
Update README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ acr_login:
 > $(ACR_LOGIN_COMMAND)
 
 ghcr_login:
-> @$(CONTAINER_ENGINE) login ghcr.io -u $(GH_USERNAME) -p $(GH_TOKEN)
+> @$(CONTAINER_ENGINE) login ghcr.io -u $(GH_USERNAME) -p $(GH_PAT)
 
 
 #######################

--- a/batch/README.md
+++ b/batch/README.md
@@ -319,10 +319,10 @@ make container_build DOCKER_COMMAND=docker
 ```
 
 ### Get the container onto the container registry
-Now we can get our container into the registry by "`push`-ing" it. First we need to authenticate to the Github container registry. You will need a [Github Personal Access Token (classic)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens). Set one up and then follow the instructions [here to log in to `ghcr.io`](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic). Github recommends storing it in an environment variable. Here and in the `Makefile`, we assume you've stored your token in the environment variable `GH_TOKEN` and your github username in the environment variable `GH_USERNAME`.
+Now we can get our container into the registry by "`push`-ing" it. First we need to authenticate to the Github container registry. You will need a [Github Personal Access Token (classic)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens). Set one up and then follow the instructions [here to log in to `ghcr.io`](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic). Github recommends storing it in an environment variable. Here and in the `Makefile`, we assume you've stored your token in the environment variable `GH_PAT` and your github username in the environment variable `GH_USERNAME`.
 
 ```bash
-docker login ghcr.io -u $GH_USERNAME -p $GH_TOKEN
+docker login ghcr.io -u $GH_USERNAME -p $GH_PAT
 ```
 
 The Makefile provides a shortcut:


### PR DESCRIPTION
Avoid clash with env var `GH_TOKEN`, which `gh` CLI uses for its own purposes