### PR TITLE
Simplify getting of node id ref in setup_pool.py

### DIFF
--- a/batch/setup_pool.py
+++ b/batch/setup_pool.py
@@ -26,7 +26,7 @@ def main(pool_name: str) -> None:
 
     creds = EnvCredentialHandler()
     client = get_batch_management_client(creds)
-    node_id_ref = creds.get_compute_node_identity_reference
+    node_id_ref = creds.compute_node_identity_reference
     mount_config = blob.get_node_mount_config(
         storage_containers=[
             "wastewater-input",

--- a/batch/setup_pool.py
+++ b/batch/setup_pool.py
@@ -5,7 +5,7 @@ import argparse
 import azuretools.defaults as d
 from azure.mgmt.batch import models
 from azuretools import blob
-from azuretools.auth import EnvCredentialHandler, get_compute_node_id_reference
+from azuretools.auth import EnvCredentialHandler
 from azuretools.client import get_batch_management_client
 
 
@@ -26,7 +26,7 @@ def main(pool_name: str) -> None:
 
     creds = EnvCredentialHandler()
     client = get_batch_management_client(creds)
-    node_id_ref = get_compute_node_id_reference()
+    node_id_ref = creds.get_compute_node_identity_reference
     mount_config = blob.get_node_mount_config(
         storage_containers=[
             "wastewater-input",


### PR DESCRIPTION
Simpler and clearer to get the compute node identity reference directly from the `CredentialHandler`. I am planning a breaking change to `cfa-azuretools` that will refactor and the rename the `get_compute_node_id_reference()` function to `get_compute_node_identity_reference()`; this change will prevent that one from breaking the pipeline.