### PR TITLE
Allow missing hub submissions in retrospective analysis

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,14 +17,10 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.9
     hooks:
-      # Sort imports
-      - id: ruff
-        args: ["check", "--select", "I", "--fix"]
         # Run the linter
-      - id: ruff
+      - id: ruff-check
         # Run the formatter
       - id: ruff-format
-        args: ["--line-length", "79"]
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.8.11
     hooks:

--- a/batch/setup_pool.py
+++ b/batch/setup_pool.py
@@ -30,7 +30,7 @@ def main(pool_name: str) -> None:
     mount_config = blob.get_node_mount_config(
         storage_containers=[
             "wastewater-input",
-            "wastewater-test-output",
+            "wastewater-ms-output",
         ],
         mount_names=["input", "output"],
         account_names=creds.azure_blob_storage_account,
@@ -41,7 +41,7 @@ def main(pool_name: str) -> None:
         subnet_id=creds.azure_subnet_id,
         user_assigned_identity=creds.azure_user_assigned_identity,
         mount_configuration=mount_config,
-        vm_size="standard_d4s_v3",
+        vm_size="standard_e8s_v3",
     )
 
     d.assign_container_config(

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,2 @@
+extend-include = ["*.ipynb"]
+line-length = 79

--- a/wweval/R/create_hub_submissions.R
+++ b/wweval/R/create_hub_submissions.R
@@ -99,13 +99,6 @@ create_hub_submissions <- function(
     )
 
     if (isTRUE(save_files)) {
-      stopifnot(
-        "Don't have forecasts for all locations, not writing to disk" = n_locs >=
-          51 # temporarily relax bc model convergence flags can
-        # lead to missing models for hosp model as well, in which case we wouldn't
-        # have submitted
-      )
-
       wwinference::create_dir(file.path(hub_subdir, model_name))
 
       readr::write_csv(


### PR DESCRIPTION
If both models had failed to converge, there would have been no submission.

Also updates ruff configuration slightly